### PR TITLE
compatibility to servant 0.8/0.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .cabal-sandbox/*
 *dist/
 *dist-newstyle/
+.stack-work/

--- a/lib/Servant/Ekg.hs
+++ b/lib/Servant/Ekg.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                 #-}
 {-# LANGUAGE DataKinds           #-}
 {-# LANGUAGE FlexibleContexts    #-}
 {-# LANGUAGE FlexibleInstances   #-}
@@ -160,3 +161,8 @@ instance ReflectMethod method => HasEndpoint (Verb method status cts a) where
 
 instance HasEndpoint (Raw) where
     getEndpoint _ _ = Just ([],"RAW")
+
+#if MIN_VERSION_servant(0,8,1)
+instance HasEndpoint (sub :: *) => HasEndpoint (CaptureAll (h :: Symbol) a :> sub) where
+    getEndpoint _ = getEndpoint (Proxy :: Proxy sub)
+#endif

--- a/servant-ekg.cabal
+++ b/servant-ekg.cabal
@@ -17,9 +17,9 @@ source-repository HEAD
 library
   exposed-modules:     Servant.Ekg
   hs-source-dirs:      lib
-  build-depends:       base >=4.7 && <4.9
+  build-depends:       base >=4.7 && < 4.10
                      , ekg-core
-                     , servant > 0.5 && < 0.8
+                     , servant > 0.5 && < 0.9
                      , http-types
                      , text
                      , time

--- a/servant-ekg.cabal
+++ b/servant-ekg.cabal
@@ -19,7 +19,7 @@ library
   hs-source-dirs:      lib
   build-depends:       base >=4.7 && < 4.10
                      , ekg-core
-                     , servant > 0.5 && < 0.9
+                     , servant > 0.5 && < 0.10
                      , http-types
                      , text
                      , time

--- a/test/Servant/EkgSpec.hs
+++ b/test/Servant/EkgSpec.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE CPP                  #-}
 {-# LANGUAGE DataKinds            #-}
 {-# LANGUAGE DeriveGeneric        #-}
-{-# LANGUAGE OverlappingInstances #-}
 {-# LANGUAGE OverloadedStrings    #-}
 {-# LANGUAGE PolyKinds            #-}
 {-# LANGUAGE TypeFamilies         #-}

--- a/test/Servant/EkgSpec.hs
+++ b/test/Servant/EkgSpec.hs
@@ -10,7 +10,9 @@
 module Servant.EkgSpec (spec) where
 
 import           Control.Concurrent
+#if !MIN_VERSION_servant(0,9,0)
 import           Control.Monad.Trans.Except
+#endif
 import           Data.Aeson
 import           Data.Monoid
 import           Data.Proxy
@@ -40,7 +42,11 @@ spec = describe "servant-ekg" $ do
   it "collects number of request" $ do
     withApp $ \port mvar -> do
       mgr <- newManager defaultManagerSettings
+#if MIN_VERSION_servant(0,9,0)
+      Right _result <- runClientM (getEp "name" Nothing) (ClientEnv mgr (BaseUrl Http "localhost" port ""))
+#else
       _result <- runExceptT $ getEp "name" Nothing mgr (BaseUrl Http "localhost" port "")
+#endif
       m <- readMVar mvar
       case H.lookup "hello.:name.GET" m of
         Nothing -> fail "Expected some value"

--- a/test/Servant/EkgSpec.hs
+++ b/test/Servant/EkgSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                  #-}
 {-# LANGUAGE DataKinds            #-}
 {-# LANGUAGE DeriveGeneric        #-}
 {-# LANGUAGE OverlappingInstances #-}
@@ -69,7 +70,11 @@ type TestApi =
   :<|> "greet" :> ReqBody '[JSON] Greet :> Post '[JSON] Greet
 
        -- DELETE /greet/:greetid
+#if MIN_VERSION_servant(0,8,0)
+  :<|> "greet" :> Capture "greetid" Text :> Delete '[JSON] NoContent
+#else
   :<|> "greet" :> Capture "greetid" Text :> Delete '[JSON] ()
+#endif
 
 testApi :: Proxy TestApi
 testApi = Proxy
@@ -89,7 +94,11 @@ server = helloH :<|> postGreetH :<|> deleteGreetH
 
         postGreetH = return
 
+#if MIN_VERSION_servant(0,8,0)
+        deleteGreetH _ = return NoContent
+#else
         deleteGreetH _ = return ()
+#endif
 
 -- Turn the server into a WAI app. 'serve' is provided by servant,
 -- more precisely by the Servant.Server module.


### PR DESCRIPTION
tested with stack resolvers lts-7.18 (ghc-8.0.1) and nightly-2017-01-29 (ghc-8.0.2)