### PR TITLE
Fix git repo

### DIFF
--- a/servant-ekg.cabal
+++ b/servant-ekg.cabal
@@ -12,7 +12,7 @@ cabal-version:       >=1.10
 
 source-repository HEAD
   type: git
-  location: https://github.com/servant/servant-ekg.git
+  location: https://github.com/haskell-servant/servant-ekg.git
 
 library
   exposed-modules:     Servant.Ekg


### PR DESCRIPTION
The link on Hackage is broken

<img width="770" alt="screen shot 2017-10-27 at 12 48 01" src="https://user-images.githubusercontent.com/1356417/32122424-1ebaffd6-bb15-11e7-9973-3877bb6c4275.png">

This change should fix it.