### PR TITLE
Add HasEndpoint instance for BasicAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# servant-ekg
+
+[![Build Status](https://travis-ci.org/haskell-servant/servant-ekg.png)](https://travis-ci.org/haskell-servant/servant-ekg)
+
+# Servant Performance Counters
+
+This package lets you track peformance counters for each of your Servant endpoints using EKG.
+
+# Usage
+
+Servant-EKG knows how to handle all official Servant combinators out of the box.
+
+## Instrumenting your API
+To use Servant-EKG, you'll need to wrap your WAI application with the Servant-EKG middleware.
+
+```
+import Network.Wai.Handler.Warp
+import System.Metrics
+import Servant.Ekg
+
+wrapWithEkg :: Proxy api -> Server api -> IO Application
+wrapWithEkg api server = do
+  store   <- newStore
+  metrics <- newMVar mempty
+
+  return $ monitorEndpoints api store metrics (serve api server)
+
+main :: IO ()
+main = do
+  let api    = ...
+      server = ...
+
+  app <- wrapWithEkg api server
+
+  run 8080 app
+```
+
+## Runtime overhead
+Instrumenting your API introduces a non-zero runtime overhead, on the order of 200 - 600 µsec depending upon your machine. It's a good idea to run the benchmarks on your intended production platform to get an idea of how large the overhead will be. You'll need to have `wrk` installed to run the benchmarks.
+
+In general, the runtime overhead should be effectively negligible if your handlers are issuing network requests, such as to databases. If you have handlers that are small, CPU-only, and requested frequently, you will see a performance hit from Servant-EKG.

--- a/README.md
+++ b/README.md
@@ -20,10 +20,9 @@ import Servant.Ekg
 
 wrapWithEkg :: Proxy api -> Server api -> IO Application
 wrapWithEkg api server = do
-  store   <- newStore
-  metrics <- newMVar mempty
+  monitorEndpoints' <- monitorEndpoints api =<< newStore
 
-  return $ monitorEndpoints api store metrics (serve api server)
+  return $ monitorEndpoints' (serve api server)
 
 main :: IO ()
 main = do

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -1,12 +1,11 @@
-{-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE DeriveGeneric        #-}
-{-# LANGUAGE OverloadedStrings    #-}
-{-# LANGUAGE PolyKinds            #-}
-{-# LANGUAGE TypeFamilies         #-}
-{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PolyKinds         #-}
+{-# LANGUAGE TypeFamilies      #-}
+{-# LANGUAGE TypeOperators     #-}
 module Main (main) where
 
-import           Control.Concurrent
 import           Data.Text                (Text)
 import           Network.Wai              (Application)
 import           Network.Wai.Handler.Warp
@@ -26,9 +25,9 @@ server = return
 
 servantEkgServer :: IO Application
 servantEkgServer = do
-  store <- newStore
-  ms <- newMVar mempty
-  return $ monitorEndpoints benchApi store ms (serve benchApi server)
+  mware <- monitorEndpoints benchApi =<< newStore
+
+  return $ mware (serve benchApi server)
 
 benchApp :: IO Application -> IO ()
 benchApp app = withApplication app $ \port ->

--- a/lib/Servant/Ekg.hs
+++ b/lib/Servant/Ekg.hs
@@ -184,3 +184,7 @@ instance HasEndpoint Raw where
 instance HasEndpoint (sub :: *) => HasEndpoint (CaptureAll (h :: Symbol) a :> sub) where
     getEndpoint        _ = getEndpoint        (Proxy :: Proxy sub)
     enumerateEndpoints _ = enumerateEndpoints (Proxy :: Proxy sub)
+
+instance HasEndpoint (sub :: *) => HasEndpoint (BasicAuth (realm :: Symbol) a :> sub) where
+    getEndpoint        _ = getEndpoint        (Proxy :: Proxy sub)
+    enumerateEndpoints _ = enumerateEndpoints (Proxy :: Proxy sub)

--- a/lib/Servant/Ekg.hs
+++ b/lib/Servant/Ekg.hs
@@ -4,10 +4,10 @@
 {-# LANGUAGE FlexibleInstances   #-}
 {-# LANGUAGE KindSignatures      #-}
 {-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE PolyKinds           #-}
 {-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators       #-}
-{-# LANGUAGE PolyKinds           #-}
 module Servant.Ekg where
 
 import           Control.Concurrent.MVar
@@ -116,6 +116,7 @@ instance (KnownSymbol (path :: Symbol), HasEndpoint (sub :: *))
                 return (p:end, method)
             _ -> Nothing
 
+
 instance (KnownSymbol (capture :: Symbol), HasEndpoint (sub :: *))
     => HasEndpoint (Capture' mods capture a :> sub) where
     getEndpoint _ req =
@@ -147,8 +148,10 @@ instance HasEndpoint (sub :: *) => HasEndpoint (QueryFlag h :> sub) where
 instance HasEndpoint (sub :: *) => HasEndpoint (ReqBody' mods cts a :> sub) where
     getEndpoint _ = getEndpoint (Proxy :: Proxy sub)
 
+#if MIN_VERSION_servant(0,15,0)
 instance HasEndpoint (sub :: *) => HasEndpoint (StreamBody' mods framing ct a :> sub) where
     getEndpoint _ = getEndpoint (Proxy :: Proxy sub)
+#endif
 
 instance HasEndpoint (sub :: *) => HasEndpoint (RemoteHost :> sub) where
     getEndpoint _ = getEndpoint (Proxy :: Proxy sub)
@@ -168,19 +171,17 @@ instance HasEndpoint (sub :: *) => HasEndpoint (WithNamedContext x y sub) where
 instance ReflectMethod method => HasEndpoint (Verb method status cts a) where
     getEndpoint _ req = case pathInfo req of
         [] | requestMethod req == method -> Just ([], method)
-        _ -> Nothing
+        _                                -> Nothing
       where method = reflectMethod (Proxy :: Proxy method)
 
 instance ReflectMethod method => HasEndpoint (Stream method status framing ct a) where
     getEndpoint _ req = case pathInfo req of
         [] | requestMethod req == method -> Just ([], method)
-        _ -> Nothing
+        _                                -> Nothing
       where method = reflectMethod (Proxy :: Proxy method)
 
-instance HasEndpoint (Raw) where
+instance HasEndpoint Raw where
     getEndpoint _ _ = Just ([],"RAW")
 
-#if MIN_VERSION_servant(0,8,1)
 instance HasEndpoint (sub :: *) => HasEndpoint (CaptureAll (h :: Symbol) a :> sub) where
     getEndpoint _ = getEndpoint (Proxy :: Proxy sub)
-#endif

--- a/lib/Servant/Ekg/Internal.hs
+++ b/lib/Servant/Ekg/Internal.hs
@@ -1,0 +1,87 @@
+{-# LANGUAGE DeriveAnyClass    #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards   #-}
+
+module Servant.Ekg.Internal where
+
+import           Control.Exception
+import           Control.Monad
+import           Data.Hashable               (Hashable (..))
+import qualified Data.HashMap.Strict         as H
+import           Data.Monoid
+import           Data.Text                   (Text)
+import qualified Data.Text                   as T
+import qualified Data.Text.Encoding          as T
+import           Data.Time.Clock
+import           GHC.Generics                (Generic)
+import           Network.HTTP.Types          (Method, Status (..))
+import           Network.Wai                 (Middleware, responseStatus)
+import           System.Metrics
+import qualified System.Metrics.Counter      as Counter
+import qualified System.Metrics.Distribution as Distribution
+import qualified System.Metrics.Gauge        as Gauge
+
+data Meters = Meters
+    { metersInflight :: Gauge.Gauge
+    , metersC2XX     :: Counter.Counter
+    , metersC4XX     :: Counter.Counter
+    , metersC5XX     :: Counter.Counter
+    , metersCXXX     :: Counter.Counter
+    , metersTime     :: Distribution.Distribution
+    }
+
+data APIEndpoint = APIEndpoint {
+    pathSegments :: [Text],
+    method       :: Method
+} deriving (Eq, Hashable, Show, Generic)
+
+gaugeInflight :: Gauge.Gauge -> Middleware
+gaugeInflight inflight application request respond =
+    bracket_ (Gauge.inc inflight)
+             (Gauge.dec inflight)
+             (application request respond)
+
+-- | Count responses with 2XX, 4XX, 5XX, and XXX response codes.
+countResponseCodes
+    :: (Counter.Counter, Counter.Counter, Counter.Counter, Counter.Counter)
+    -> Middleware
+countResponseCodes (c2XX, c4XX, c5XX, cXXX) application request respond =
+    application request respond'
+  where
+    respond' res = count (responseStatus res) >> respond res
+    count Status{statusCode = sc }
+        | 200 <= sc && sc < 300 = Counter.inc c2XX
+        | 400 <= sc && sc < 500 = Counter.inc c4XX
+        | 500 <= sc && sc < 600 = Counter.inc c5XX
+        | otherwise             = Counter.inc cXXX
+
+responseTimeDistribution :: Distribution.Distribution -> Middleware
+responseTimeDistribution dist application request respond =
+    bracket getCurrentTime stop $ const $ application request respond
+  where
+    stop t1 = do
+        t2 <- getCurrentTime
+        let dt = diffUTCTime t2 t1
+        Distribution.add dist $ fromRational $ (*1000) $ toRational dt
+
+initializeMeters :: Store -> APIEndpoint -> IO Meters
+initializeMeters store APIEndpoint{..} = do
+    metersInflight <- createGauge        (prefix <> "in_flight") store
+    metersC2XX     <- createCounter      (prefix <> "responses.2XX") store
+    metersC4XX     <- createCounter      (prefix <> "responses.4XX") store
+    metersC5XX     <- createCounter      (prefix <> "responses.5XX") store
+    metersCXXX     <- createCounter      (prefix <> "responses.XXX") store
+    metersTime     <- createDistribution (prefix <> "time_ms") store
+
+    return Meters{..}
+
+    where
+        prefix = "servant.path." <> path <> "."
+        path   = T.intercalate "." $ pathSegments <> [T.decodeUtf8 method]
+
+initializeMetersTable :: Store -> [APIEndpoint] -> IO (H.HashMap APIEndpoint Meters)
+initializeMetersTable store endpoints = do
+    meters <- mapM (initializeMeters store) endpoints
+
+    return $ H.fromList (zip endpoints meters)

--- a/servant-ekg.cabal
+++ b/servant-ekg.cabal
@@ -1,6 +1,6 @@
 cabal-version: >=1.10
 name:          servant-ekg
-version:       0.3.0.0
+version:       0.3.1.0
 synopsis:      Helpers for using ekg with servant
 description:   Helpers for using ekg with servant, e.g.. counters per endpoint.
 license:       BSD3

--- a/servant-ekg.cabal
+++ b/servant-ekg.cabal
@@ -1,6 +1,6 @@
 cabal-version: >=1.10
 name:          servant-ekg
-version:       0.2.2.0
+version:       0.3.0.0
 synopsis:      Helpers for using ekg with servant
 description:   Helpers for using ekg with servant, e.g.. counters per endpoint.
 license:       BSD3
@@ -21,11 +21,13 @@ source-repository HEAD
 
 library
   exposed-modules:  Servant.Ekg
+  other-modules:    Servant.Ekg.Internal
   hs-source-dirs:   lib
   build-depends:
       base                  >=4.9      && <4.13
     , ekg-core              >=0.1.1.4  && <0.2
     , http-types            >=0.12.2   && <0.13
+    , hashable              >=1.2.7.0  && <1.3
     , servant               >=0.14     && <0.16
     , text                  >=1.2.3.0  && <1.3
     , time                  >=1.6.0.1  && <1.9

--- a/servant-ekg.cabal
+++ b/servant-ekg.cabal
@@ -1,6 +1,6 @@
 cabal-version: >=1.10
 name:          servant-ekg
-version:       0.2.1.0
+version:       0.2.2.0
 synopsis:      Helpers for using ekg with servant
 description:   Helpers for using ekg with servant, e.g.. counters per endpoint.
 license:       BSD3
@@ -24,13 +24,13 @@ library
   hs-source-dirs:   lib
   build-depends:
       base                  >=4.9      && <4.13
-    , ekg-core              >=0.1.1.6  && <0.2
+    , ekg-core              >=0.1.1.4  && <0.2
     , http-types            >=0.12.2   && <0.13
-    , servant               >=0.15     && <0.16
+    , servant               >=0.14     && <0.16
     , text                  >=1.2.3.0  && <1.3
     , time                  >=1.6.0.1  && <1.9
     , unordered-containers  >=0.2.9.0  && <0.3
-    , wai                   >=3.2.2    && <3.3
+    , wai                   >=3.2.0    && <3.3
 
   default-language: Haskell2010
 

--- a/test/Servant/EkgSpec.hs
+++ b/test/Servant/EkgSpec.hs
@@ -1,28 +1,34 @@
-{-# LANGUAGE CPP                  #-}
-{-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE DeriveGeneric        #-}
-{-# LANGUAGE OverloadedStrings    #-}
-{-# LANGUAGE PolyKinds            #-}
-{-# LANGUAGE TypeFamilies         #-}
-{-# LANGUAGE TypeOperators        #-}
+{-# LANGUAGE CPP               #-}
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PolyKinds         #-}
+{-# LANGUAGE RankNTypes        #-}
+{-# LANGUAGE TypeFamilies      #-}
+{-# LANGUAGE TypeOperators     #-}
 
 module Servant.EkgSpec (spec) where
 
 import           Control.Concurrent
 import           Data.Aeson
-import           Data.Monoid
+import qualified Data.HashMap.Strict                        as H
+import           Data.Monoid                                ((<>))
 import           Data.Proxy
-import qualified Data.HashMap.Strict as H
 import           Data.Text
 import           GHC.Generics
-import           Network.HTTP.Client (defaultManagerSettings, newManager)
+import           Network.HTTP.Client                        (defaultManagerSettings,
+                                                             newManager)
 import           Network.Wai
 import           Network.Wai.Handler.Warp
 import           Servant
 import           Servant.Client
-import           Servant.Test.ComprehensiveAPI (comprehensiveAPI)
+#if MIN_VERSION_servant(0,15,0)
+import           Servant.Test.ComprehensiveAPI              (comprehensiveAPI)
+#else
+import           Servant.API.Internal.Test.ComprehensiveAPI (comprehensiveAPI)
+#endif
 import           System.Metrics
-import qualified System.Metrics.Counter as Counter
+import qualified System.Metrics.Counter                     as Counter
 import           Test.Hspec
 
 import           Servant.Ekg
@@ -35,7 +41,7 @@ spec = describe "servant-ekg" $ do
 
   let getEp :<|> postEp :<|> deleteEp = client testApi
 
-  it "collects number of request" $ do
+  it "collects number of request" $
     withApp $ \port mvar -> do
       mgr <- newManager defaultManagerSettings
       let runFn :: ClientM a -> IO (Either ServantError a)
@@ -98,11 +104,7 @@ server = helloH :<|> postGreetH :<|> deleteGreetH
 
         postGreetH = return
 
-#if MIN_VERSION_servant(0,8,0)
         deleteGreetH _ = return NoContent
-#else
-        deleteGreetH _ = return ()
-#endif
 
 -- Turn the server into a WAI app. 'serve' is provided by servant,
 -- more precisely by the Servant.Server module.

--- a/test/Servant/EkgSpec.hs
+++ b/test/Servant/EkgSpec.hs
@@ -9,7 +9,6 @@
 
 module Servant.EkgSpec (spec) where
 
-import           Control.Concurrent
 import           Data.Aeson
 import qualified Data.HashMap.Strict                        as H
 import           Data.Monoid                                ((<>))
@@ -28,7 +27,6 @@ import           Servant.Test.ComprehensiveAPI              (comprehensiveAPI)
 import           Servant.API.Internal.Test.ComprehensiveAPI (comprehensiveAPI)
 #endif
 import           System.Metrics
-import qualified System.Metrics.Counter                     as Counter
 import           Test.Hspec
 
 import           Servant.Ekg
@@ -42,28 +40,35 @@ spec = describe "servant-ekg" $ do
   let getEp :<|> postEp :<|> deleteEp = client testApi
 
   it "collects number of request" $
-    withApp $ \port mvar -> do
+    withApp $ \port store -> do
       mgr <- newManager defaultManagerSettings
       let runFn :: ClientM a -> IO (Either ServantError a)
           runFn fn = runClientM fn (mkClientEnv mgr (BaseUrl Http "localhost" port ""))
       _ <- runFn $ getEp "name" Nothing
       _ <- runFn $ postEp (Greet "hi")
       _ <- runFn $ deleteEp "blah"
-      m <- readMVar mvar
-      case H.lookup "hello.:name.GET" m of
+
+      m <- sampleAll store
+      case H.lookup "servant.path.hello.:name.GET.responses.2XX" m of
         Nothing -> fail "Expected some value"
-        Just v  -> Counter.read (metersC2XX v) `shouldReturn` 1
-      case H.lookup "greet.POST" m of
+        Just v  -> v `shouldBe` Counter 1
+      case H.lookup "servant.path.greet.POST.responses.2XX" m of
         Nothing -> fail "Expected some value"
-        Just v  -> Counter.read (metersC2XX v) `shouldReturn` 1
-      case H.lookup "greet.:greetid.DELETE" m of
+        Just v  -> v `shouldBe` Counter 1
+      case H.lookup "servant.path.greet.:greetid.DELETE.responses.2XX" m of
         Nothing -> fail "Expected some value"
-        Just v  -> Counter.read (metersC2XX v) `shouldReturn` 1
+        Just v  -> v `shouldBe` Counter 1
 
   it "is comprehensive" $ do
-    let _typeLevelTest = monitorEndpoints comprehensiveAPI undefined undefined undefined
+    _typeLevelTest <- monitorEndpoints comprehensiveAPI =<< newStore
     True `shouldBe` True
 
+  it "enumerates the parts of an API correctly" $
+    enumerateEndpoints testApi `shouldBe` [
+      APIEndpoint ["hello",":name"] "GET",
+      APIEndpoint ["greet"] "POST",
+      APIEndpoint ["greet",":greetid"] "DELETE"
+    ]
 
 -- * Example
 
@@ -111,8 +116,8 @@ server = helloH :<|> postGreetH :<|> deleteGreetH
 test :: Application
 test = serve testApi server
 
-withApp :: (Port -> MVar (H.HashMap Text Meters) -> IO a) -> IO a
+withApp :: (Port -> Store -> IO a) -> IO a
 withApp a = do
   ekg <- newStore
-  ms <- newMVar mempty
-  withApplication (return $ monitorEndpoints testApi ekg ms test) $ \p -> a p ms
+  monitorEndpoints' <- monitorEndpoints testApi ekg
+  withApplication (return $ monitorEndpoints' test) $ \p -> a p ekg


### PR DESCRIPTION
Depends on #9 

Does what it says on the tin -- `BasicAuth` isn't a member of `Servant.Test.ComprehensiveAPI`, so the ordinary test misses it.