### PR TITLE
Support for ghc 8.8.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,9 @@ before_cache:
   - rm -rfv $CABALHOME/packages/head.hackage
 jobs:
   include:
+    - compiler: ghc-8.8.3
+      addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-8.8.3","cabal-install-3.0"]}}
+      os: linux
     - compiler: ghc-8.6.5
       addons: {"apt":{"sources":[{"sourceline":"deb http://ppa.launchpad.net/hvr/ghc/ubuntu xenial main","key_url":"https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x063dab2bdc0b3f9fcebc378bff3aeacef6f88286"}],"packages":["ghc-8.6.5","cabal-install-3.0"]}}
       os: linux

--- a/servant-ekg.cabal
+++ b/servant-ekg.cabal
@@ -13,7 +13,7 @@ maintainer:
 
 category:      Servant, Web, System
 build-type:    Simple
-tested-with:   GHC ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.5
+tested-with:   GHC ==8.0.2 || ==8.2.2 || ==8.4.4 || ==8.6.5 || ==8.8.3
 extra-source-files: README.md CHANGELOG.md
 
 source-repository HEAD
@@ -25,13 +25,13 @@ library
   other-modules:    Servant.Ekg.Internal
   hs-source-dirs:   lib
   build-depends:
-      base                  >=4.9      && <4.13
+      base                  >=4.9      && <4.14
     , ekg-core              >=0.1.1.4  && <0.2
     , http-types            >=0.12.2   && <0.13
     , hashable              >=1.2.7.0  && <1.4
     , servant               >=0.14     && <0.18
     , text                  >=1.2.3.0  && <1.3
-    , time                  >=1.6.0.1  && <1.9
+    , time                  >=1.6.0.1  && <1.10
     , unordered-containers  >=0.2.9.0  && <0.3
     , wai                   >=3.2.0    && <3.3
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,3 @@
-resolver: lts-13.6
+resolver: lts-16.10
 packages:
 - '.'
-extra-deps:
-- ekg-0.4.0.15
-- ekg-json-0.1.0.6


### PR DESCRIPTION
* Loosen version bounds for `base` and `time`
* Update to `lts-16.10`