### PR TITLE
Loosen Library Constraints

### DIFF
--- a/servant-ekg.cabal
+++ b/servant-ekg.cabal
@@ -26,14 +26,14 @@ library
   hs-source-dirs:   lib
   build-depends:
       base                  >=4.9      && <5
-    , ekg-core              >=0.1.1.4  && <0.2
+    , ekg-core              >=0.1.1.4  && <1
     , http-types            >=0.12.2   && <0.13
     , hashable              >=1.2.7.0  && <1.4
-    , servant               >=0.14     && <0.18
-    , text                  >=1.2.3.0  && <1.3
-    , time                  >=1.6.0.1  && <1.9
+    , servant               >=0.14     && <0.19
+    , text                  >=1.2.3.0  && <2
+    , time                  >=1.6.0.1  && <2
     , unordered-containers  >=0.2.9.0  && <0.3
-    , wai                   >=3.2.0    && <3.3
+    , wai                   >=3.2.0    && <4
 
   default-language: Haskell2010
 
@@ -78,4 +78,4 @@ benchmark bench
     , servant-server
     , text
     , wai
-    , warp            >=3.2.4 && <3.3
+    , warp            >=3.2.4 && <4

--- a/servant-ekg.cabal
+++ b/servant-ekg.cabal
@@ -25,7 +25,7 @@ library
   other-modules:    Servant.Ekg.Internal
   hs-source-dirs:   lib
   build-depends:
-      base                  >=4.9      && <4.13
+      base                  >=4.9      && <5
     , ekg-core              >=0.1.1.4  && <0.2
     , http-types            >=0.12.2   && <0.13
     , hashable              >=1.2.7.0  && <1.4


### PR DESCRIPTION
I was having a super hard time getting cabal to resolve any dependencies once I added this because the bounds on all the libraries are extremely tight. I may have loosened it too much for your taste, but this worked for me so I figured I'd at least open a PR to see if you're interested.