### PR TITLE
bump `servant` upper bound

### DIFF
--- a/servant-ekg.cabal
+++ b/servant-ekg.cabal
@@ -29,7 +29,7 @@ library
     , ekg-core              >=0.1.1.4  && <0.2
     , http-types            >=0.12.2   && <0.13
     , hashable              >=1.2.7.0  && <1.4
-    , servant               >=0.14     && <0.19
+    , servant               >=0.14     && <0.20
     , text                  >=1.2.3.0  && <1.3
     , time                  >=1.6.0.1  && <1.12
     , unordered-containers  >=0.2.9.0  && <0.3


### PR DESCRIPTION
compilation succeeds with `servant-0.19`